### PR TITLE
Require `alchemist-compile` in alchemist.el

### DIFF
--- a/alchemist.el
+++ b/alchemist.el
@@ -71,6 +71,7 @@
 (require 'alchemist-hooks)
 (require 'alchemist-message)
 (require 'alchemist-iex)
+(require 'alchemist-compile)
 (require 'alchemist-refcard)
 (require 'alchemist-complete)
 (require 'alchemist-company)


### PR DESCRIPTION
In current version, compile commands do not work as `alchemist-compile` is not included in `alchemist.el`.
